### PR TITLE
Add Unix domain socket server with session handling and sendmail cmd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /golubsmtpd
+/sendmail
 /test-spool/
 /test-mail/
 /pprof/*.png

--- a/cmd/golubsmtpd/main_test.go
+++ b/cmd/golubsmtpd/main_test.go
@@ -47,7 +47,7 @@ func TestInitializeSpoolDirectoriesPermissions(t *testing.T) {
 			t.Fatalf("Failed to stat directory %s: %v", dir, err)
 		}
 
-		expectedPerm := os.FileMode(0700)
+		expectedPerm := os.FileMode(0o700)
 		actualPerm := info.Mode().Perm()
 		if actualPerm != expectedPerm {
 			t.Errorf("Directory %s has permissions %o, expected %o (secure permissions required for email data)",
@@ -79,7 +79,7 @@ func TestInitializeSpoolDirectoriesWithCustomPath(t *testing.T) {
 		}
 
 		// Verify secure permissions on custom path too
-		if info.Mode().Perm() != 0700 {
+		if info.Mode().Perm() != 0o700 {
 			t.Errorf("Custom path directory %s has insecure permissions %o", dir, info.Mode().Perm())
 		}
 	}
@@ -112,7 +112,7 @@ func TestInitializeSpoolDirectoriesIdempotent(t *testing.T) {
 			continue
 		}
 
-		if info.Mode().Perm() != 0700 {
+		if info.Mode().Perm() != 0o700 {
 			t.Errorf("Directory %s has wrong permissions after second call: %o", dir, info.Mode().Perm())
 		}
 	}

--- a/cmd/sendmail/main.go
+++ b/cmd/sendmail/main.go
@@ -1,0 +1,303 @@
+package main
+
+import (
+	"bufio"
+	"flag"
+	"fmt"
+	"io"
+	"net"
+	"net/textproto"
+	"os"
+	"strings"
+	"time"
+)
+
+const (
+	defaultSocketPath = "/var/run/golubsmtpd/golubsmtpd.sock"
+)
+
+// SendmailArgs represents parsed command line arguments
+type SendmailArgs struct {
+	SocketPath string
+	From       string
+	To         []string
+	ReadTo     bool
+	Verbose    bool
+}
+
+func main() {
+	args, err := parseArgs()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+
+	if args.Verbose {
+		fmt.Fprintf(os.Stderr, "sendmail: connecting to %s\n", args.SocketPath)
+	}
+
+	// Read message from stdin
+	message, err := readMessage(os.Stdin)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error reading message: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Parse recipients from message if -t flag is used
+	if args.ReadTo {
+		recipients, cleanMessage := extractRecipients(message)
+		args.To = append(args.To, recipients...)
+		message = cleanMessage
+	}
+
+	if len(args.To) == 0 {
+		fmt.Fprintf(os.Stderr, "Error: No recipients specified\n")
+		os.Exit(1)
+	}
+
+	// Connect to socket and send message
+	if err := sendMessage(args, message); err != nil {
+		fmt.Fprintf(os.Stderr, "Error sending message: %v\n", err)
+		os.Exit(1)
+	}
+
+	if args.Verbose {
+		fmt.Fprintf(os.Stderr, "sendmail: message sent successfully\n")
+	}
+}
+
+// parseArgs parses command line arguments in sendmail-compatible format
+func parseArgs() (*SendmailArgs, error) {
+	args := &SendmailArgs{
+		SocketPath: defaultSocketPath,
+		To:         make([]string, 0),
+	}
+
+	// Define flags
+	flag.StringVar(&args.SocketPath, "socket", defaultSocketPath, "Path to golubsmtpd socket")
+	flag.StringVar(&args.From, "f", "", "Set sender address")
+	flag.StringVar(&args.From, "from", "", "Set sender address (alias for -f)")
+	flag.BoolVar(&args.ReadTo, "t", false, "Read recipients from message headers")
+	flag.BoolVar(&args.Verbose, "v", false, "Verbose output")
+
+	// Custom usage
+	flag.Usage = func() {
+		fmt.Fprintf(os.Stderr, "Usage: %s [options] recipient...\n", os.Args[0])
+		fmt.Fprintf(os.Stderr, "\nOptions:\n")
+		flag.PrintDefaults()
+		fmt.Fprintf(os.Stderr, "\nExample:\n")
+		fmt.Fprintf(os.Stderr, "  echo 'Hello World' | %s user@example.com\n", os.Args[0])
+		fmt.Fprintf(os.Stderr, "  %s -f sender@example.com -t < message.txt\n", os.Args[0])
+	}
+
+	flag.Parse()
+
+	// Remaining arguments are recipients
+	args.To = append(args.To, flag.Args()...)
+
+	// Set default sender if not specified
+	if args.From == "" {
+		// Get current user as default sender
+		if user := os.Getenv("USER"); user != "" {
+			hostname, _ := os.Hostname()
+			if hostname == "" {
+				hostname = "localhost"
+			}
+			args.From = user + "@" + hostname
+		}
+	}
+
+	return args, nil
+}
+
+// readMessage reads the entire message from stdin
+func readMessage(reader io.Reader) (string, error) {
+	var builder strings.Builder
+	scanner := bufio.NewScanner(reader)
+
+	for scanner.Scan() {
+		builder.WriteString(scanner.Text())
+		builder.WriteString("\r\n") // SMTP requires CRLF
+	}
+
+	if err := scanner.Err(); err != nil {
+		return "", fmt.Errorf("error reading input: %w", err)
+	}
+
+	return builder.String(), nil
+}
+
+// extractRecipients parses To:, Cc:, Bcc: headers from message and returns recipients and cleaned message
+func extractRecipients(message string) ([]string, string) {
+	lines := strings.Split(message, "\r\n")
+	recipients := make([]string, 0)
+	cleanLines := make([]string, 0)
+	inHeaders := true
+
+	for _, line := range lines {
+		// Empty line indicates end of headers
+		if inHeaders && line == "" {
+			inHeaders = false
+			cleanLines = append(cleanLines, line)
+			continue
+		}
+
+		if inHeaders {
+			// Parse recipient headers
+			if strings.HasPrefix(strings.ToLower(line), "to:") {
+				recipients = append(recipients, parseAddressLine(line[3:])...)
+			} else if strings.HasPrefix(strings.ToLower(line), "cc:") {
+				recipients = append(recipients, parseAddressLine(line[3:])...)
+			} else if strings.HasPrefix(strings.ToLower(line), "bcc:") {
+				recipients = append(recipients, parseAddressLine(line[4:])...)
+				continue // Remove Bcc: header from message
+			}
+		}
+
+		cleanLines = append(cleanLines, line)
+	}
+
+	return recipients, strings.Join(cleanLines, "\r\n")
+}
+
+// parseAddressLine parses email addresses from a header line
+func parseAddressLine(line string) []string {
+	addresses := make([]string, 0)
+	// Simple parsing - split by comma and clean up
+	parts := strings.Split(line, ",")
+	for _, part := range parts {
+		addr := strings.TrimSpace(part)
+		// Extract email from "Name <email>" format
+		if idx := strings.LastIndex(addr, "<"); idx != -1 {
+			if endIdx := strings.Index(addr[idx:], ">"); endIdx != -1 {
+				addr = addr[idx+1 : idx+endIdx]
+			}
+		}
+		addr = strings.TrimSpace(addr)
+		if addr != "" {
+			addresses = append(addresses, addr)
+		}
+	}
+	return addresses
+}
+
+// sendMessage connects to the socket and sends the message using simplified SMTP
+func sendMessage(args *SendmailArgs, message string) error {
+	// Connect to Unix domain socket
+	conn, err := net.DialTimeout("unix", args.SocketPath, 10*time.Second)
+	if err != nil {
+		return fmt.Errorf("failed to connect to socket %s: %w", args.SocketPath, err)
+	}
+	defer conn.Close()
+
+	// Set timeouts
+	conn.SetDeadline(time.Now().Add(30 * time.Second))
+
+	// Create textproto connection for SMTP communication
+	textConn := textproto.NewConn(conn)
+	defer textConn.Close()
+
+	if args.Verbose {
+		fmt.Fprintf(os.Stderr, "sendmail: connected to socket\n")
+	}
+
+	// Send MAIL FROM command
+	mailCmd := fmt.Sprintf("MAIL FROM:<%s>", args.From)
+	if args.Verbose {
+		fmt.Fprintf(os.Stderr, "sendmail: > %s\n", mailCmd)
+	}
+
+	if err := textConn.PrintfLine("%s", mailCmd); err != nil {
+		return fmt.Errorf("failed to send MAIL command: %w", err)
+	}
+
+	// Read response
+	if _, err := readResponse(textConn, args.Verbose); err != nil {
+		return fmt.Errorf("MAIL FROM failed: %w", err)
+	}
+
+	// Send RCPT TO commands for each recipient
+	for _, recipient := range args.To {
+		rcptCmd := fmt.Sprintf("RCPT TO:<%s>", recipient)
+		if args.Verbose {
+			fmt.Fprintf(os.Stderr, "sendmail: > %s\n", rcptCmd)
+		}
+
+		if err := textConn.PrintfLine("%s", rcptCmd); err != nil {
+			return fmt.Errorf("failed to send RCPT command: %w", err)
+		}
+
+		if _, err := readResponse(textConn, args.Verbose); err != nil {
+			return fmt.Errorf("RCPT TO failed for %s: %w", recipient, err)
+		}
+	}
+
+	// Send DATA command
+	if args.Verbose {
+		fmt.Fprintf(os.Stderr, "sendmail: > DATA\n")
+	}
+
+	if err := textConn.PrintfLine("DATA"); err != nil {
+		return fmt.Errorf("failed to send DATA command: %w", err)
+	}
+
+	// Read 354 response
+	response, err := readResponse(textConn, args.Verbose)
+	if err != nil {
+		return fmt.Errorf("DATA command failed: %w", err)
+	}
+	if !strings.HasPrefix(response, "354") {
+		return fmt.Errorf("unexpected DATA response: %s", response)
+	}
+
+	// Send message data
+	if args.Verbose {
+		fmt.Fprintf(os.Stderr, "sendmail: sending message data (%d bytes)\n", len(message))
+	}
+
+	// Send message followed by termination sequence
+	if err := textConn.PrintfLine("%s", message); err != nil {
+		return fmt.Errorf("failed to send message data: %w", err)
+	}
+
+	if err := textConn.PrintfLine("."); err != nil {
+		return fmt.Errorf("failed to send message termination: %w", err)
+	}
+
+	// Read final response
+	if _, err := readResponse(textConn, args.Verbose); err != nil {
+		return fmt.Errorf("message transmission failed: %w", err)
+	}
+
+	// Send QUIT
+	if args.Verbose {
+		fmt.Fprintf(os.Stderr, "sendmail: > QUIT\n")
+	}
+
+	textConn.PrintfLine("QUIT")
+	readResponse(textConn, args.Verbose) // Don't fail on QUIT response
+
+	return nil
+}
+
+// readResponse reads and validates SMTP response
+func readResponse(conn *textproto.Conn, verbose bool) (string, error) {
+	response, err := conn.ReadLine()
+	if err != nil {
+		return "", err
+	}
+
+	if verbose {
+		fmt.Fprintf(os.Stderr, "sendmail: < %s\n", response)
+	}
+
+	// Check if response indicates success (2xx or 3xx)
+	if len(response) >= 3 {
+		code := response[:3]
+		if strings.HasPrefix(code, "2") || strings.HasPrefix(code, "3") {
+			return response, nil
+		}
+	}
+
+	return response, fmt.Errorf("SMTP error: %s", response)
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -29,6 +29,8 @@ type ServerConfig struct {
 	VirtualDomains      []string      `yaml:"virtual_domains"`
 	RelayDomains        []string      `yaml:"relay_domains"`
 	SpoolDir            string        `yaml:"spool_dir"`
+	SocketPath          string        `yaml:"socket_path"`
+	TrustedUsers        []string      `yaml:"trusted_users"`
 }
 
 type TLSConfig struct {
@@ -70,8 +72,11 @@ type LoggingConfig struct {
 }
 
 type QueueConfig struct {
-	BufferSize   int `yaml:"buffer_size"`
-	MaxConsumers int `yaml:"max_consumers"`
+	BufferSize     int           `yaml:"buffer_size"`
+	MaxConsumers   int           `yaml:"max_consumers"`
+	PublishTimeout time.Duration `yaml:"publish_timeout"`
+	RetryDelay     time.Duration `yaml:"retry_delay"`
+	MaxRetryDelay  time.Duration `yaml:"max_retry_delay"`
 }
 
 type DeliveryConfig struct {
@@ -80,7 +85,8 @@ type DeliveryConfig struct {
 }
 
 type LocalDeliveryConfig struct {
-	MaxWorkers int `yaml:"max_workers"`
+	BaseDirPath string `yaml:"base_dir_path"`
+	MaxWorkers  int    `yaml:"max_workers"`
 }
 
 type VirtualDeliveryConfig struct {
@@ -120,6 +126,8 @@ func DefaultConfig() *Config {
 			VirtualDomains:      []string{"mail.localhost"}, // Virtual users
 			RelayDomains:        []string{},                 // No relay by default
 			SpoolDir:            "/var/spool/golubsmtpd",
+			SocketPath:          "/var/run/golubsmtpd/golubsmtpd.sock",
+			TrustedUsers:        []string{"root", "mail", "daemon"},
 		},
 		TLS: TLSConfig{
 			Enabled: false,

--- a/internal/delivery/testing.go
+++ b/internal/delivery/testing.go
@@ -28,7 +28,7 @@ func newTestSetup(t *testing.T, messageID string) *testSetup {
 	testContent := "Subject: Test Message\r\nFrom: test@example.com\r\n\r\nTest message content"
 	testMessagePath := filepath.Join(tempDir, "test_message.eml")
 
-	if err := os.WriteFile(testMessagePath, []byte(testContent), 0644); err != nil {
+	if err := os.WriteFile(testMessagePath, []byte(testContent), 0o644); err != nil {
 		t.Fatalf("Failed to create test message: %v", err)
 	}
 

--- a/internal/delivery/types.go
+++ b/internal/delivery/types.go
@@ -26,4 +26,5 @@ type DeliveryResult struct {
 type DeliveryOutcome struct {
 	Recipient string
 	Success   bool
+	Error     error
 }

--- a/internal/queue/spool.go
+++ b/internal/queue/spool.go
@@ -17,7 +17,7 @@ import (
 func InitializeSpoolDirectories(spoolDir string) error {
 	for _, state := range GetRequiredSpoolDirectories() {
 		dir := filepath.Join(spoolDir, string(state))
-		if err := os.MkdirAll(dir, 0700); err != nil {
+		if err := os.MkdirAll(dir, 0o700); err != nil {
 			return fmt.Errorf("failed to create spool directory %s: %w", dir, err)
 		}
 	}
@@ -52,7 +52,7 @@ func StreamEmailContent(ctx context.Context, cfg *config.Config, message *Messag
 	}
 
 	// Create temporary file with secure permissions (0600 = rw-------)
-	file, err := os.OpenFile(tempFile, os.O_CREATE|os.O_RDWR|os.O_EXCL, 0600)
+	file, err := os.OpenFile(tempFile, os.O_CREATE|os.O_RDWR|os.O_EXCL, 0o600)
 	if err != nil {
 		return 0, fmt.Errorf("failed to create temporary file %s: %w", tempFile, err)
 	}

--- a/internal/queue/spool_test.go
+++ b/internal/queue/spool_test.go
@@ -226,7 +226,7 @@ func TestInitializeSpoolDirectories(t *testing.T) {
 			continue
 		}
 
-		if info.Mode().Perm() != 0700 {
+		if info.Mode().Perm() != 0o700 {
 			t.Errorf("Directory %s has wrong permissions. Expected: 0700, Got: %o", dir, info.Mode().Perm())
 		}
 	}

--- a/internal/queue/types.go
+++ b/internal/queue/types.go
@@ -5,8 +5,10 @@ import (
 )
 
 // Re-export types for compatibility
-type Message = types.Message
-type MessageState = types.MessageState
+type (
+	Message      = types.Message
+	MessageState = types.MessageState
+)
 
 const (
 	MessageStateIncoming   = types.MessageStateIncoming
@@ -16,5 +18,7 @@ const (
 )
 
 // Re-export functions
-var GenerateID = types.GenerateID
-var GetRequiredSpoolDirectories = types.GetRequiredSpoolDirectories
+var (
+	GenerateID                  = types.GenerateID
+	GetRequiredSpoolDirectories = types.GetRequiredSpoolDirectories
+)

--- a/internal/server/unixsocket.go
+++ b/internal/server/unixsocket.go
@@ -1,0 +1,215 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/textproto"
+	"os"
+	"os/user"
+	"path/filepath"
+	"strconv"
+	"syscall"
+
+	"github.com/pawciobiel/golubsmtpd/internal/smtp"
+)
+
+// startSocketListener creates and starts the Unix domain socket listener
+func (srv *Server) startSocketListener(ctx context.Context) error {
+	socketPath := srv.config.Server.SocketPath
+	if socketPath == "" {
+		srv.logger.Info("Unix domain socket disabled (no socket_path configured)")
+		return nil
+	}
+
+	// Create directory if it doesn't exist
+	socketDir := filepath.Dir(socketPath)
+	if err := os.MkdirAll(socketDir, 0o755); err != nil {
+		return fmt.Errorf("failed to create socket directory: %w", err)
+	}
+
+	// Remove existing socket file if it exists
+	if err := os.Remove(socketPath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("failed to remove existing socket file: %w", err)
+	}
+
+	// Create Unix domain socket
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		return fmt.Errorf("failed to create Unix domain socket at %s: %w", socketPath, err)
+	}
+
+	srv.socketListen = listener
+
+	// Set socket permissions (666) - allow all users like Postfix
+	if err := os.Chmod(socketPath, 0o666); err != nil {
+		listener.Close()
+		return fmt.Errorf("failed to set socket permissions: %w", err)
+	}
+
+	// Keep current ownership (don't force mail group)
+	srv.logger.Debug("Socket permissions set to 666 (all users can access)")
+
+	srv.logger.Info("Unix domain socket listener started", "socket_path", socketPath)
+
+	// Start accepting socket connections
+	srv.wg.Add(1)
+	go srv.socketAcceptLoop(ctx)
+
+	return nil
+}
+
+// socketAcceptLoop accepts connections on the Unix domain socket
+func (srv *Server) socketAcceptLoop(ctx context.Context) {
+	defer srv.wg.Done()
+	defer func() {
+		if srv.socketListen != nil {
+			srv.socketListen.Close()
+			// Clean up socket file
+			if socketPath := srv.config.Server.SocketPath; socketPath != "" {
+				os.Remove(socketPath)
+			}
+		}
+	}()
+
+	for {
+		select {
+		case <-srv.shutdown:
+			return
+		default:
+		}
+
+		conn, err := srv.socketListen.Accept()
+		if err != nil {
+			select {
+			case <-srv.shutdown:
+				return
+			default:
+				srv.logger.Error("Failed to accept socket connection", "error", err)
+				continue
+			}
+		}
+
+		srv.wg.Add(1)
+		go srv.handleSocketConnection(ctx, conn)
+	}
+}
+
+// handleSocketConnection handles a single Unix domain socket connection
+func (srv *Server) handleSocketConnection(ctx context.Context, conn net.Conn) {
+	defer srv.wg.Done()
+	defer conn.Close()
+
+	srv.logger.Debug("New socket connection accepted")
+
+	// Get peer credentials (UID, GID, PID) from Unix socket
+	credentials, err := srv.getSocketCredentials(conn)
+	if err != nil {
+		srv.logger.Error("Failed to get socket credentials", "error", err)
+		return
+	}
+
+	srv.logger.Debug("Socket connection credentials",
+		"uid", credentials.UID,
+		"gid", credentials.GID,
+		"pid", credentials.PID)
+
+	// Validate the connecting process
+	if !srv.isSocketConnectionValid(credentials) {
+		srv.logger.Warn("Socket connection validation failed")
+		return
+	}
+
+	// Create connection context for socket - convert credentials
+	smtpCreds := &smtp.SocketCredentials{
+		UID: credentials.UID,
+		GID: credentials.GID,
+		PID: credentials.PID,
+	}
+
+	connCtx := smtp.ConnectionContext{
+		Type:        smtp.ConnectionTypeSocket,
+		Credentials: smtpCreds,
+	}
+
+	// Create SMTP handler using factory
+	textprotoConn := textproto.NewConn(conn)
+	handler := smtp.NewSMTPHandler(connCtx, srv.config, srv.logger, textprotoConn, srv.authenticator, srv.queue)
+
+	if err := handler.Handle(ctx); err != nil {
+		srv.logger.Debug("Socket SMTP session ended", "error", err)
+	} else {
+		srv.logger.Debug("Socket SMTP session completed successfully")
+	}
+}
+
+// SocketCredentials represents Unix socket peer credentials
+type SocketCredentials struct {
+	UID int // User ID
+	GID int // Group ID
+	PID int // Process ID
+}
+
+// getSocketCredentials retrieves peer credentials from Unix socket
+func (srv *Server) getSocketCredentials(conn net.Conn) (*SocketCredentials, error) {
+	unixConn, ok := conn.(*net.UnixConn)
+	if !ok {
+		return nil, fmt.Errorf("connection is not a Unix socket")
+	}
+
+	// Get raw connection file descriptor
+	file, err := unixConn.File()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get connection file: %w", err)
+	}
+	defer file.Close()
+
+	fd := int(file.Fd())
+
+	// Get peer credentials using SO_PEERCRED
+	ucred, err := syscall.GetsockoptUcred(fd, syscall.SOL_SOCKET, syscall.SO_PEERCRED)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get peer credentials: %w", err)
+	}
+
+	return &SocketCredentials{
+		UID: int(ucred.Uid),
+		GID: int(ucred.Gid),
+		PID: int(ucred.Pid),
+	}, nil
+}
+
+// isSocketConnectionValid validates the connecting process and user
+func (srv *Server) isSocketConnectionValid(creds *SocketCredentials) bool {
+	// Check if user is in trusted users list
+	username, err := srv.getUsernameFromUID(creds.UID)
+	if err != nil {
+		srv.logger.Error("Failed to get username for UID", "uid", creds.UID, "error", err)
+		return false
+	}
+
+	// For now, allow all users - sender validation will happen in SMTP session
+	// This allows regular users to connect, but they'll be restricted in MAIL FROM
+	srv.logger.Debug("Socket connection from user", "username", username, "uid", creds.UID)
+
+	return true
+}
+
+// getUsernameFromUID converts UID to username
+func (srv *Server) getUsernameFromUID(uid int) (string, error) {
+	u, err := user.LookupId(strconv.Itoa(uid))
+	if err != nil {
+		return "", err
+	}
+	return u.Username, nil
+}
+
+// isTrustedUser checks if a user is in the trusted users list
+func (srv *Server) isTrustedUser(username string) bool {
+	for _, trustedUser := range srv.config.Server.TrustedUsers {
+		if trustedUser == username {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/smtp/handler.go
+++ b/internal/smtp/handler.go
@@ -1,0 +1,113 @@
+package smtp
+
+import (
+	"context"
+	"log/slog"
+	"net/textproto"
+
+	"github.com/pawciobiel/golubsmtpd/internal/auth"
+	"github.com/pawciobiel/golubsmtpd/internal/config"
+	"github.com/pawciobiel/golubsmtpd/internal/queue"
+)
+
+// ConnectionType represents the type of connection
+type ConnectionType string
+
+const (
+	ConnectionTypeTCP    ConnectionType = "tcp"
+	ConnectionTypeSocket ConnectionType = "socket"
+)
+
+// ConnectionContext contains information about the connection
+type ConnectionContext struct {
+	Type        ConnectionType
+	Port        int
+	TLS         bool
+	ClientIP    string
+	Credentials *SocketCredentials
+}
+
+// SocketCredentials represents Unix socket peer credentials
+type SocketCredentials struct {
+	UID int // User ID
+	GID int // Group ID
+	PID int // Process ID
+}
+
+// SMTPHandler interface for handling SMTP sessions
+type SMTPHandler interface {
+	Handle(ctx context.Context) error
+}
+
+// Strategy interfaces for different session behaviors
+type HeaderGenerator interface {
+	GenerateHeaders(msg *queue.Message, connCtx ConnectionContext) string
+}
+
+type SenderValidator interface {
+	ValidateSender(sender string) error
+	IsAuthenticated() bool
+	GetUsername() string
+}
+
+type DataHandler interface {
+	HandleData(ctx context.Context, args []string, sess *Session) error
+	HandleAuth(ctx context.Context, args []string, sess *Session) error
+	HandleMail(ctx context.Context, args []string, sess *Session) error
+}
+
+// NewSMTPHandler creates appropriate SMTP handler based on connection context
+func NewSMTPHandler(
+	connCtx ConnectionContext,
+	cfg *config.Config,
+	logger *slog.Logger,
+	textproto *textproto.Conn,
+	authenticator auth.Authenticator,
+	queue *queue.Queue,
+) SMTPHandler {
+	// Create appropriate validator based on connection type
+	validator := createSenderValidator(connCtx, cfg, authenticator, logger)
+
+	logger.Debug("Creating SMTP handler", "connection_type", connCtx.Type)
+
+	switch connCtx.Type {
+	case ConnectionTypeSocket:
+		logger.Debug("Creating socket session")
+		return NewSocketSession(connCtx.Credentials, cfg, logger, textproto, validator, authenticator, queue)
+	case ConnectionTypeTCP:
+		logger.Debug("Creating TCP session")
+		return NewTCPSession(connCtx, cfg, logger, textproto, validator, authenticator, queue)
+	default:
+		logger.Error("Unknown connection type", "type", connCtx.Type)
+		return NewTCPSession(connCtx, cfg, logger, textproto, validator, authenticator, queue)
+	}
+}
+
+// createSenderValidator creates appropriate validator based on connection context
+func createSenderValidator(
+	connCtx ConnectionContext,
+	cfg *config.Config,
+	authenticator auth.Authenticator,
+	logger *slog.Logger,
+) SenderValidator {
+	switch connCtx.Type {
+	case ConnectionTypeSocket:
+		return NewSocketSenderValidator(connCtx.Credentials, cfg, logger)
+	case ConnectionTypeTCP:
+		// Different validation based on port
+		switch connCtx.Port {
+		case 587: // Submission port - requires authentication
+			return NewSubmissionSenderValidator(authenticator, cfg)
+		case 25: // MTA port - relay rules apply
+			return NewRelayValidator(cfg, logger)
+		case 465: // SMTPS port - requires authentication
+			return NewSubmissionSenderValidator(authenticator, cfg)
+		default:
+			logger.Warn("Unknown TCP port, using relay validator", "port", connCtx.Port)
+			return NewRelayValidator(cfg, logger)
+		}
+	default:
+		logger.Error("Unknown connection type for validator", "type", connCtx.Type)
+		return NewRelayValidator(cfg, logger)
+	}
+}

--- a/internal/smtp/rcpt.go
+++ b/internal/smtp/rcpt.go
@@ -85,10 +85,10 @@ func (r *RcptValidator) IsVirtualUserEmailValid(ctx context.Context, email strin
 		r.logger.Debug("Virtual user cache hit", "email", email, "exists", cachedResult)
 		return cachedResult
 	}
-	
+
 	exists := r.authenticator.ValidateUser(ctx, email)
 	r.virtualCache.Put(email, exists)
-	
+
 	r.logger.Debug("Virtual user lookup", "email", email, "exists", exists)
 	return exists
 }

--- a/internal/smtp/sessions.go
+++ b/internal/smtp/sessions.go
@@ -1,0 +1,141 @@
+package smtp
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/textproto"
+
+	"github.com/pawciobiel/golubsmtpd/internal/auth"
+	"github.com/pawciobiel/golubsmtpd/internal/config"
+	"github.com/pawciobiel/golubsmtpd/internal/queue"
+)
+
+// tcpSessionHandler handles the standard TCP SMTP session flow
+func tcpSessionHandler(ctx context.Context, sess *Session) error {
+	defer sess.textproto.Close()
+
+	sess.logger.Info("Starting SMTP session", "client_ip", sess.clientIP)
+
+	// Send greeting
+	if err := sess.sendGreeting(); err != nil {
+		return fmt.Errorf("failed to send greeting: %w", err)
+	}
+
+	// Process commands
+	for sess.state != StateClosed {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		line, err := sess.textproto.ReadLine()
+		if err != nil {
+			sess.logger.Debug("Error reading command", "error", err)
+			return err
+		}
+
+		sess.logger.Debug("Received command", "command", line, "client_ip", sess.clientIP)
+
+		if err := sess.processCommand(ctx, line); err != nil {
+			sess.logger.Error("Error processing command", "error", err, "command", line)
+			return err
+		}
+	}
+
+	return nil
+}
+
+// NewTCPSession creates a new TCP session with appropriate strategies
+func NewTCPSession(
+	connCtx ConnectionContext,
+	cfg *config.Config,
+	logger *slog.Logger,
+	textproto *textproto.Conn,
+	validator SenderValidator,
+	authenticator auth.Authenticator,
+	queue *queue.Queue,
+) SMTPHandler {
+	// Create TCP-specific strategies
+	headerGenerator := &TCPHeaderGenerator{}
+	dataHandler := &TCPDataHandler{}
+
+	// Create session with strategies and handler
+	return NewSession(cfg, logger, textproto, connCtx.ClientIP, authenticator, queue,
+		headerGenerator, validator, dataHandler, tcpSessionHandler, connCtx)
+}
+
+// socketSessionHandler handles Unix domain socket SMTP session flow
+func socketSessionHandler(ctx context.Context, sess *Session) error {
+	defer sess.textproto.Close()
+
+	sess.logger.Debug("Starting socket SMTP session", "username", sess.username)
+
+	// Socket sessions skip greeting and go straight to SMTP commands
+	sess.state = StateGreeted
+
+	// Process commands using embedded session logic
+	for sess.state != StateClosed {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		line, err := sess.textproto.ReadLine()
+		if err != nil {
+			sess.logger.Debug("Error reading command", "error", err)
+			return err
+		}
+
+		sess.logger.Debug("Socket SMTP command", "command", line, "username", sess.username)
+
+		// Use embedded session's processCommand
+		if err := sess.processCommand(ctx, line); err != nil {
+			sess.logger.Error("Error processing socket command", "error", err, "command", line)
+			return err
+		}
+	}
+
+	return nil
+}
+
+// NewSocketSession creates a new socket session with appropriate strategies
+func NewSocketSession(
+	credentials *SocketCredentials,
+	cfg *config.Config,
+	logger *slog.Logger,
+	textproto *textproto.Conn,
+	validator SenderValidator,
+	authenticator auth.Authenticator,
+	queue *queue.Queue,
+) SMTPHandler {
+	// Get username from UID
+	username, err := getUsernameFromUID(credentials.UID)
+	if err != nil {
+		logger.Error("Failed to get username from UID", "uid", credentials.UID, "error", err)
+		username = fmt.Sprintf("uid-%d", credentials.UID)
+	}
+
+	// Create socket-specific strategies
+	headerGenerator := &SocketHeaderGenerator{}
+	dataHandler := &SocketDataHandler{}
+
+	// Create connection context for socket
+	connCtx := ConnectionContext{
+		Type:        ConnectionTypeSocket,
+		ClientIP:    "socket",
+		Credentials: credentials,
+	}
+
+	// Create session with strategies and handler
+	session := NewSession(cfg, logger, textproto, "socket", authenticator, queue,
+		headerGenerator, validator, dataHandler, socketSessionHandler, connCtx)
+
+	// Mark as already authenticated since socket connections are kernel-verified
+	session.authenticated = true
+	session.username = username
+
+	return session
+}

--- a/internal/smtp/strategies_socket.go
+++ b/internal/smtp/strategies_socket.go
@@ -1,0 +1,166 @@
+package smtp
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/pawciobiel/golubsmtpd/internal/queue"
+)
+
+// SocketHeaderGenerator adds all missing headers for socket connections
+type SocketHeaderGenerator struct{}
+
+func (g *SocketHeaderGenerator) GenerateHeaders(msg *queue.Message, connCtx ConnectionContext) string {
+	var headers strings.Builder
+
+	// Add Received header for socket connections
+	timestamp := time.Now().UTC().Format("Mon, 02 Jan 2006 15:04:05 UTC")
+	headers.WriteString(fmt.Sprintf("Received: from localhost (unix socket) by localhost; %s\r\n",
+		timestamp))
+
+	// Add missing basic headers for socket-delivered messages
+	headers.WriteString(fmt.Sprintf("From: %s\r\n", msg.From))
+
+	// Add To header(s) - combine all recipients
+	var recipients []string
+	for recipient := range msg.LocalRecipients {
+		recipients = append(recipients, recipient)
+	}
+	for recipient := range msg.VirtualRecipients {
+		recipients = append(recipients, recipient)
+	}
+	for recipient := range msg.RelayRecipients {
+		recipients = append(recipients, recipient)
+	}
+	for recipient := range msg.ExternalRecipients {
+		recipients = append(recipients, recipient)
+	}
+
+	if len(recipients) > 0 {
+		headers.WriteString(fmt.Sprintf("To: %s\r\n", strings.Join(recipients, ", ")))
+	}
+
+	// Add Date header (using UTC)
+	headers.WriteString(fmt.Sprintf("Date: %s\r\n", msg.Created.UTC().Format("Mon, 02 Jan 2006 15:04:05 UTC")))
+
+	// Add our internal message ID for tracing
+	headers.WriteString(fmt.Sprintf("GolubSMTPd-Message-ID: %s\r\n", msg.ID))
+
+	// Add empty line to separate headers from body
+	headers.WriteString("\r\n")
+
+	return headers.String()
+}
+
+// SocketDataHandler handles DATA command for Unix socket connections
+type SocketDataHandler struct{}
+
+func (h *SocketDataHandler) HandleData(ctx context.Context, args []string, sess *Session) error {
+	// Check session state - must have at least one recipient
+	if sess.state != StateRcptTo {
+		return sess.writeResponse(Response(StatusBadSequence, "RCPT TO required before DATA"))
+	}
+
+	if sess.currentMessage.TotalRecipients() == 0 {
+		return sess.writeResponse(Response(StatusBadSequence, "No recipients specified"))
+	}
+
+	// Start data collection
+	sess.state = StateData
+	if err := sess.writeResponse(Response(StatusStartMailInput, "Start mail input; end with <CRLF>.<CRLF>")); err != nil {
+		return err
+	}
+
+	// Generate headers using the strategy (includes all missing headers)
+	headers := sess.headerGenerator.GenerateHeaders(sess.currentMessage, sess.connCtx)
+
+	// Create a reader that combines headers and message data
+	var messageReader io.Reader
+	if headers != "" {
+		headerReader := strings.NewReader(headers)
+		messageReader = io.MultiReader(headerReader, sess.textproto.R)
+	} else {
+		messageReader = sess.textproto.R
+	}
+
+	// Stream message data directly to storage
+	totalSize, err := queue.StreamEmailContent(ctx, sess.config, sess.currentMessage, messageReader)
+	if err != nil {
+		sess.logger.Error("Error storing message data", "error", err, "client_ip", sess.clientIP)
+		return sess.writeResponse(Response(StatusLocalError, "Error storing message"))
+	}
+
+	// Update message size after successful storage
+	sess.currentMessage.TotalSize = totalSize
+
+	sess.logger.Info("Socket message received and stored",
+		"sender", sess.currentMessage.From,
+		"total_recipients", sess.currentMessage.TotalRecipients(),
+		"size", totalSize,
+		"message_id", sess.currentMessage.ID,
+		"username", sess.senderValidator.GetUsername())
+
+	// Publish message to queue for processing
+	if err := sess.queue.PublishMessage(ctx, sess.currentMessage); err != nil {
+		sess.logger.Error("Error publishing message to queue", "error", err, "message_id", sess.currentMessage.ID)
+		// Don't fail the SMTP transaction - message is already stored
+	}
+
+	// Reset session for next mail transaction
+	sess.resetSession()
+
+	return sess.writeResponse(Response(StatusOK, "Message accepted for delivery"))
+}
+
+// HandleAuth for socket connections - authentication not needed
+func (h *SocketDataHandler) HandleAuth(ctx context.Context, args []string, sess *Session) error {
+	return sess.writeResponse(Response(StatusBadSequence, "Authentication not required for local connections"))
+}
+
+// HandleMail for socket connections - use socket-specific sender validation
+func (h *SocketDataHandler) HandleMail(ctx context.Context, args []string, sess *Session) error {
+	if sess.state != StateGreeted {
+		return sess.writeResponse(Response(StatusBadSequence, "Bad sequence of commands"))
+	}
+
+	if len(args) == 0 {
+		return sess.writeResponse(Response(StatusSyntaxError, "MAIL command requires FROM parameter"))
+	}
+
+	// Parse MAIL FROM using existing EmailValidator (RFC compliant)
+	emailValidator := NewEmailValidator(sess.config)
+	emailAddr, err := emailValidator.ParseMailFromCommand(args)
+	if err != nil {
+		return sess.writeResponse(Response(StatusSyntaxError, err.Error()))
+	}
+
+	sender := emailAddr.Full
+
+	// Use socket validator for sender validation
+	if err := sess.senderValidator.ValidateSender(sender); err != nil {
+		sess.logger.Warn("Socket sender validation failed",
+			"sender", sender,
+			"username", sess.senderValidator.GetUsername(),
+			"error", err)
+		return sess.writeResponse(Response(StatusMailboxUnavailable, "Sender address not allowed"))
+	}
+
+	// Create new message using proper Message struct
+	sess.currentMessage = &queue.Message{
+		From:               sender,
+		ClientIP:           "socket",
+		LocalRecipients:    make(map[string]struct{}),
+		VirtualRecipients:  make(map[string]struct{}),
+		RelayRecipients:    make(map[string]struct{}),
+		ExternalRecipients: make(map[string]struct{}),
+		Created:            time.Now(),
+	}
+	// Generate ID for the message
+	sess.currentMessage.ID = queue.GenerateID()
+
+	sess.state = StateMailFrom
+	return sess.writeResponse(Response(StatusOK, "OK"))
+}

--- a/internal/smtp/strategies_tcp.go
+++ b/internal/smtp/strategies_tcp.go
@@ -1,0 +1,103 @@
+package smtp
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/pawciobiel/golubsmtpd/internal/queue"
+)
+
+// TCPHeaderGenerator adds Received header and GolubSMTPd-Message-ID for TCP connections
+type TCPHeaderGenerator struct{}
+
+func (g *TCPHeaderGenerator) GenerateHeaders(msg *queue.Message, connCtx ConnectionContext) string {
+	var headers strings.Builder
+
+	// Add Received header for message tracing
+	clientInfo := connCtx.ClientIP
+	// TODO: Add client hostname from HELO/EHLO if available
+
+	timestamp := time.Now().UTC().Format("Mon, 02 Jan 2006 15:04:05 UTC")
+	headers.WriteString(fmt.Sprintf("Received: from %s by localhost; %s\r\n",
+		clientInfo, timestamp))
+
+	// Add our internal message ID for tracing
+	headers.WriteString(fmt.Sprintf("GolubSMTPd-Message-ID: %s\r\n", msg.ID))
+
+	return headers.String()
+}
+
+// TCPDataHandler handles DATA command for TCP connections
+type TCPDataHandler struct{}
+
+func (h *TCPDataHandler) HandleData(ctx context.Context, args []string, sess *Session) error {
+	// Check session state - must have at least one recipient
+	if sess.state != StateRcptTo {
+		return sess.writeResponse(Response(StatusBadSequence, "RCPT TO required before DATA"))
+	}
+
+	if sess.currentMessage.TotalRecipients() == 0 {
+		return sess.writeResponse(Response(StatusBadSequence, "No recipients specified"))
+	}
+
+	// Start data collection
+	sess.state = StateData
+	if err := sess.writeResponse(Response(StatusStartMailInput, "Start mail input; end with <CRLF>.<CRLF>")); err != nil {
+		return err
+	}
+
+	// Generate headers using the strategy
+	headers := sess.headerGenerator.GenerateHeaders(sess.currentMessage, sess.connCtx)
+
+	// Create a reader that combines headers and message data
+	var messageReader io.Reader
+	if headers != "" {
+		headerReader := strings.NewReader(headers)
+		messageReader = io.MultiReader(headerReader, sess.textproto.R)
+	} else {
+		messageReader = sess.textproto.R
+	}
+
+	// Stream message data directly to storage
+	totalSize, err := queue.StreamEmailContent(ctx, sess.config, sess.currentMessage, messageReader)
+	if err != nil {
+		sess.logger.Error("Error storing message data", "error", err, "client_ip", sess.clientIP)
+		return sess.writeResponse(Response(StatusLocalError, "Error storing message"))
+	}
+
+	// Update message size after successful storage
+	sess.currentMessage.TotalSize = totalSize
+
+	sess.logger.Info("TCP message received and stored",
+		"sender", sess.currentMessage.From,
+		"total_recipients", sess.currentMessage.TotalRecipients(),
+		"size", totalSize,
+		"message_id", sess.currentMessage.ID,
+		"client_ip", sess.clientIP)
+
+	// Publish message to queue for processing
+	if err := sess.queue.PublishMessage(ctx, sess.currentMessage); err != nil {
+		sess.logger.Error("Error publishing message to queue", "error", err, "message_id", sess.currentMessage.ID)
+		// Don't fail the SMTP transaction - message is already stored
+	}
+
+	// Reset session for next mail transaction
+	sess.resetSession()
+
+	return sess.writeResponse(Response(StatusOK, "Message accepted for delivery"))
+}
+
+// HandleAuth for TCP connections - use default session logic
+func (h *TCPDataHandler) HandleAuth(ctx context.Context, args []string, sess *Session) error {
+	// Delegate to default session AUTH handling
+	return sess.handleAuth(ctx, args)
+}
+
+// HandleMail for TCP connections - use default session logic
+func (h *TCPDataHandler) HandleMail(ctx context.Context, args []string, sess *Session) error {
+	// Delegate to default session MAIL handling
+	return sess.handleMail(ctx, args)
+}

--- a/internal/smtp/validators.go
+++ b/internal/smtp/validators.go
@@ -1,0 +1,178 @@
+package smtp
+
+import (
+	"fmt"
+	"log/slog"
+	"os/user"
+	"strconv"
+	"strings"
+
+	"github.com/pawciobiel/golubsmtpd/internal/auth"
+	"github.com/pawciobiel/golubsmtpd/internal/config"
+)
+
+// SocketSenderValidator validates senders for Unix socket connections
+type SocketSenderValidator struct {
+	credentials *SocketCredentials
+	username    string
+	config      *config.Config
+	logger      *slog.Logger
+}
+
+// NewSocketSenderValidator creates a new socket sender validator
+func NewSocketSenderValidator(creds *SocketCredentials, cfg *config.Config, logger *slog.Logger) *SocketSenderValidator {
+	username, err := getUsernameFromUID(creds.UID)
+	if err != nil {
+		logger.Error("Failed to get username from UID", "uid", creds.UID, "error", err)
+		username = fmt.Sprintf("uid-%d", creds.UID)
+	}
+
+	return &SocketSenderValidator{
+		credentials: creds,
+		username:    username,
+		config:      cfg,
+		logger:      logger,
+	}
+}
+
+func (v *SocketSenderValidator) ValidateSender(sender string) error {
+	// Empty sender (bounce messages) - only allow for trusted users
+	if sender == "" {
+		if v.isTrustedUser() {
+			return nil
+		}
+		return fmt.Errorf("null sender not allowed for user %s", v.username)
+	}
+
+	// Trusted users can send as anyone (like Postfix)
+	if v.isTrustedUser() {
+		return nil
+	}
+
+	// Regular users can only send as themselves for local domains
+	allowedSenders := v.getAllowedSenders()
+	for _, allowed := range allowedSenders {
+		if strings.EqualFold(sender, allowed) {
+			return nil
+		}
+	}
+
+	return fmt.Errorf("user %s not allowed to send as %s", v.username, sender)
+}
+
+func (v *SocketSenderValidator) IsAuthenticated() bool {
+	return true // Socket connections are always "authenticated" via kernel
+}
+
+func (v *SocketSenderValidator) GetUsername() string {
+	return v.username
+}
+
+func (v *SocketSenderValidator) isTrustedUser() bool {
+	for _, trustedUser := range v.config.Server.TrustedUsers {
+		if trustedUser == v.username {
+			return true
+		}
+	}
+	return false
+}
+
+func (v *SocketSenderValidator) getAllowedSenders() []string {
+	// Allow user@localdomain for each local domain (like Postfix)
+	allowed := make([]string, 0, len(v.config.Server.LocalDomains))
+	for _, domain := range v.config.Server.LocalDomains {
+		allowed = append(allowed, v.username+"@"+domain)
+	}
+	return allowed
+}
+
+// SubmissionSenderValidator validates senders for submission ports (587, 465)
+type SubmissionSenderValidator struct {
+	authenticator auth.Authenticator
+	config        *config.Config
+	authenticated bool
+	username      string
+}
+
+// NewSubmissionSenderValidator creates a new submission sender validator
+func NewSubmissionSenderValidator(authenticator auth.Authenticator, cfg *config.Config) *SubmissionSenderValidator {
+	return &SubmissionSenderValidator{
+		authenticator: authenticator,
+		config:        cfg,
+		authenticated: false,
+	}
+}
+
+func (v *SubmissionSenderValidator) ValidateSender(sender string) error {
+	// Submission ports require authentication
+	if !v.authenticated {
+		return fmt.Errorf("authentication required for sender validation")
+	}
+
+	// Empty sender not allowed on submission ports
+	if sender == "" {
+		return fmt.Errorf("null sender not allowed on submission port")
+	}
+
+	// For now, authenticated users can send as anyone
+	// TODO: Add proper sender restrictions based on user permissions
+	return nil
+}
+
+func (v *SubmissionSenderValidator) IsAuthenticated() bool {
+	return v.authenticated
+}
+
+func (v *SubmissionSenderValidator) GetUsername() string {
+	return v.username
+}
+
+// SetAuthenticated marks the user as authenticated
+func (v *SubmissionSenderValidator) SetAuthenticated(username string) {
+	v.authenticated = true
+	v.username = username
+}
+
+// RelayValidator validates senders for relay port (25)
+type RelayValidator struct {
+	config *config.Config
+	logger *slog.Logger
+}
+
+// NewRelayValidator creates a new relay validator
+func NewRelayValidator(cfg *config.Config, logger *slog.Logger) *RelayValidator {
+	return &RelayValidator{
+		config: cfg,
+		logger: logger,
+	}
+}
+
+func (v *RelayValidator) ValidateSender(sender string) error {
+	// On port 25, we're more permissive as this is for MTA-to-MTA communication
+	// TODO: Add proper relay rules, SPF checking, etc.
+
+	// Allow empty sender for bounce messages
+	if sender == "" {
+		return nil
+	}
+
+	// For now, allow any sender - proper relay rules will be added later
+	return nil
+}
+
+func (v *RelayValidator) IsAuthenticated() bool {
+	return false // Port 25 typically doesn't require authentication
+}
+
+func (v *RelayValidator) GetUsername() string {
+	return "" // No user for unauthenticated connections
+}
+
+// getUsernameFromUID converts UID to username
+func getUsernameFromUID(uid int) (string, error) {
+	u, err := user.LookupId(strconv.Itoa(uid))
+	if err != nil {
+		return "", err
+	}
+	return u.Username, nil
+}

--- a/smtpd-tester/internal/client/client.go
+++ b/smtpd-tester/internal/client/client.go
@@ -77,7 +77,7 @@ func New(config *Config, logger *slog.Logger) *Client {
 	if logger == nil {
 		logger = slog.Default()
 	}
-	
+
 	return &Client{
 		config: config,
 		logger: logger,
@@ -113,7 +113,7 @@ Random data: %x
 Test complete.`, id, time.Now().Format(time.RFC3339), randBytes)
 		}
 	}
-	
+
 	return &Message{
 		ID:        id,
 		From:      c.config.From,
@@ -126,11 +126,11 @@ Test complete.`, id, time.Now().Format(time.RFC3339), randBytes)
 
 func (c *Client) SendMessage(ctx context.Context, msg *Message) error {
 	addr := fmt.Sprintf("%s:%d", c.config.Host, c.config.Port)
-	
+
 	// Use strings.Builder for efficient message construction
 	var builder strings.Builder
 	builder.Grow(len(msg.Subject) + len(msg.From) + len(msg.To) + len(msg.Body) + 200)
-	
+
 	builder.WriteString("Subject: ")
 	builder.WriteString(msg.Subject)
 	builder.WriteString("\r\nFrom: ")
@@ -141,22 +141,22 @@ func (c *Client) SendMessage(ctx context.Context, msg *Message) error {
 	builder.WriteString(fmt.Sprintf("%d-%d", msg.ID, time.Now().UnixNano()))
 	builder.WriteString("@example.com>\r\n\r\n")
 	builder.WriteString(msg.Body)
-	
+
 	messageBody := builder.String()
-	
+
 	// Setup authentication if provided
 	var auth smtp.Auth
 	if c.config.User != "" && c.config.Password != "" {
 		auth = smtp.PlainAuth("", c.config.User, c.config.Password, c.config.Host)
 	}
-	
+
 	// Use context with timeout for the entire operation
 	timeoutCtx, cancel := context.WithTimeout(ctx, c.config.Timeout)
 	defer cancel()
-	
+
 	// Channel to capture the result of smtp.SendMail
 	done := make(chan error, 1)
-	
+
 	go func() {
 		err := smtp.SendMail(
 			addr,
@@ -167,7 +167,7 @@ func (c *Client) SendMessage(ctx context.Context, msg *Message) error {
 		)
 		done <- err
 	}()
-	
+
 	select {
 	case <-timeoutCtx.Done():
 		return fmt.Errorf("timeout sending message %d: %w", msg.ID, timeoutCtx.Err())
@@ -180,11 +180,11 @@ func (c *Client) SendMessage(ctx context.Context, msg *Message) error {
 }
 
 type SendOptions struct {
-	Messages    int
-	Workers     int
-	CustomBody  string
-	OnProgress  func(processed, total int64, rate float64)
-	OnMessage   func(msgID int, success bool, err error, duration time.Duration)
+	Messages   int
+	Workers    int
+	CustomBody string
+	OnProgress func(processed, total int64, rate float64)
+	OnMessage  func(msgID int, success bool, err error, duration time.Duration)
 }
 
 func (c *Client) SendMessages(ctx context.Context, opts SendOptions) error {
@@ -194,15 +194,15 @@ func (c *Client) SendMessages(ctx context.Context, opts SendOptions) error {
 	if opts.Workers < 1 {
 		opts.Workers = 1
 	}
-	
+
 	c.stats.Reset()
 	c.stats.Total = int64(opts.Messages)
-	
+
 	mode := "sequential"
 	if opts.Workers > 1 {
 		mode = "concurrent"
 	}
-	
+
 	c.logger.Info("Starting SMTP test",
 		"messages", opts.Messages,
 		"workers", opts.Workers,
@@ -210,12 +210,12 @@ func (c *Client) SendMessages(ctx context.Context, opts SendOptions) error {
 		"recipients", len(c.config.Recipients),
 		"target", fmt.Sprintf("%s:%d", c.config.Host, c.config.Port),
 	)
-	
+
 	// Semaphore channel pattern from go-idioms
 	type token struct{}
 	sem := make(chan token, opts.Workers)
 	var wg sync.WaitGroup
-	
+
 	// Progress reporter goroutine
 	if opts.OnProgress != nil {
 		progressCtx, cancelProgress := context.WithCancel(ctx)
@@ -224,7 +224,7 @@ func (c *Client) SendMessages(ctx context.Context, opts SendOptions) error {
 			defer wg.Done()
 			ticker := time.NewTicker(time.Second)
 			defer ticker.Stop()
-			
+
 			for {
 				select {
 				case <-progressCtx.Done():
@@ -239,13 +239,13 @@ func (c *Client) SendMessages(ctx context.Context, opts SendOptions) error {
 				}
 			}
 		}()
-		
+
 		// Ensure progress goroutine is cleaned up
 		defer func() {
 			cancelProgress()
 		}()
 	}
-	
+
 	// Send all messages using semaphore channel pattern
 	for i := 1; i <= opts.Messages; i++ {
 		sem <- token{} // Acquire semaphore
@@ -255,31 +255,31 @@ func (c *Client) SendMessages(ctx context.Context, opts SendOptions) error {
 				<-sem // Release semaphore
 				wg.Done()
 			}()
-			
+
 			msg := c.generateMessage(msgID, opts.CustomBody)
-			
+
 			start := time.Now()
 			err := c.SendMessage(ctx, msg)
 			duration := time.Since(start)
-			
+
 			success := err == nil
 			if success {
 				c.stats.AddSuccess()
 			} else {
 				c.stats.AddError()
 			}
-			
+
 			if opts.OnMessage != nil {
 				opts.OnMessage(msgID, success, err, duration)
 			}
-			
+
 			// Small delay between messages for sequential mode
 			if opts.Workers == 1 {
 				time.Sleep(100 * time.Millisecond)
 			}
 		}(i)
 	}
-	
+
 	wg.Wait()
 	return nil
 }
@@ -289,7 +289,7 @@ func (c *Client) PrintStats() {
 	success := c.stats.GetSuccess()
 	errors := c.stats.GetErrors()
 	total := c.stats.GetProcessed()
-	
+
 	fmt.Printf("\n=== Test Results ===\n")
 	fmt.Printf("Total messages: %d\n", c.stats.Total)
 	fmt.Printf("Processed: %d\n", total)

--- a/smtpd-tester/internal/test/load.go
+++ b/smtpd-tester/internal/test/load.go
@@ -29,9 +29,9 @@ func DefaultLoadTestOptions() SimpleLoadTestOptions {
 // SimpleLoadTest performs a basic SMTP load test
 func SimpleLoadTest(ctx context.Context, config *client.Config, opts SimpleLoadTestOptions, logger *slog.Logger) error {
 	ValidateConfig(config)
-	
+
 	smtpClient := client.New(config, logger)
-	
+
 	fmt.Printf("SMTP Load Test\n")
 	fmt.Printf("==============\n")
 	fmt.Printf("Target: %s:%d\n", config.Host, config.Port)
@@ -49,7 +49,7 @@ func SimpleLoadTest(ctx context.Context, config *client.Config, opts SimpleLoadT
 	}
 	fmt.Printf("Timeout: %s\n", config.Timeout)
 	fmt.Printf("\n")
-	
+
 	// Setup callbacks
 	onProgress := func(processed, total int64, rate float64) {
 		logger.Info("Progress",
@@ -60,7 +60,7 @@ func SimpleLoadTest(ctx context.Context, config *client.Config, opts SimpleLoadT
 			"rate", fmt.Sprintf("%.1f msg/sec", rate),
 		)
 	}
-	
+
 	onMessage := func(msgID int, success bool, err error, duration time.Duration) {
 		if opts.Workers == 1 {
 			if success {
@@ -76,7 +76,7 @@ func SimpleLoadTest(ctx context.Context, config *client.Config, opts SimpleLoadT
 			}
 		}
 	}
-	
+
 	sendOpts := client.SendOptions{
 		Messages:   opts.Messages,
 		Workers:    opts.Workers,
@@ -84,11 +84,11 @@ func SimpleLoadTest(ctx context.Context, config *client.Config, opts SimpleLoadT
 		OnProgress: onProgress,
 		OnMessage:  onMessage,
 	}
-	
+
 	if err := smtpClient.SendMessages(ctx, sendOpts); err != nil {
 		return fmt.Errorf("load test failed: %w", err)
 	}
-	
+
 	smtpClient.PrintStats()
 	return nil
 }

--- a/smtpd-tester/internal/test/registry.go
+++ b/smtpd-tester/internal/test/registry.go
@@ -54,7 +54,7 @@ func RunTest(ctx context.Context, testName string, config *client.Config, logger
 	if err != nil {
 		return err
 	}
-	
+
 	logger.Info("Running test", "name", testInfo.Name, "description", testInfo.Description)
 	return testInfo.Func(ctx, config, logger)
 }

--- a/smtpd-tester/internal/test/utils.go
+++ b/smtpd-tester/internal/test/utils.go
@@ -12,21 +12,21 @@ func ParseRecipients(recipients string) []string {
 	if recipients == "" {
 		return []string{client.DefaultRecipient}
 	}
-	
+
 	parts := strings.Split(recipients, ",")
 	// Pre-allocate slice capacity for efficiency
 	result := make([]string, 0, len(parts))
-	
+
 	for _, part := range parts {
 		if trimmed := strings.TrimSpace(part); trimmed != "" {
 			result = append(result, trimmed)
 		}
 	}
-	
+
 	if len(result) == 0 {
 		return []string{client.DefaultRecipient}
 	}
-	
+
 	return result
 }
 
@@ -35,23 +35,23 @@ func ValidateConfig(config *client.Config) {
 	if config.Host == "" {
 		config.Host = "127.0.0.1"
 	}
-	
+
 	if config.Port <= 0 || config.Port > 65535 {
 		config.Port = 2525
 	}
-	
+
 	if config.From == "" {
 		config.From = "sender@example.com"
 	}
-	
+
 	if len(config.Recipients) == 0 {
 		config.Recipients = []string{client.DefaultRecipient}
 	}
-	
+
 	if config.Subject == "" {
 		config.Subject = "Test Message"
 	}
-	
+
 	if config.Timeout <= 0 {
 		config.Timeout = 5 * time.Second
 	}

--- a/test-config.yaml
+++ b/test-config.yaml
@@ -17,9 +17,6 @@ server:
 tls:
   enabled: false
 
-maildir:
-  base_path: "./test-mail"
-
 auth:
   plugin_chain: ["memory"]
   plugins:
@@ -52,6 +49,7 @@ queue:
 delivery:
   local:
     max_workers: 10
+    base_dir_path: "./test-mail/localhost"
   virtual:
     base_dir_path: "./test-mail"
     max_workers: 10


### PR DESCRIPTION
* Strategy pattern / Composition + interfaces for TCP vs Socket behavior differences
* Implement sendmail command-line tool for socket communication
* Add configurable queue timing parameters and testing/synctest
* Fix local delivery with improved permission error handling
  - delivering to delivery.local.base_dir_path
* Add delivery error logging and better permission diagnostics
* Format code with gofumpt